### PR TITLE
Add react hooks plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ npm install --save-dev --save-exact eslint-config-danbriggs5-react
 npm install --save-dev --save-exact eslint@5.16.0
 npm install --save-dev --save-exact eslint-plugin-import@2.16.0
 npm install --save-dev --save-exact eslint-plugin-react@7.13.0
+npm install --save-dev --save-exact eslint-plugin-react-hooks@1.6.1
 ```
 
 ## Sample usage

--- a/index.js
+++ b/index.js
@@ -10,11 +10,14 @@ module.exports = {
 	// need to install it as a peer-dep. Better to add it manually.
 	extends: [...base.extends.map(require.resolve), 'plugin:react/recommended'],
 	parserOptions: Object.assign({}, base.parserOptions, { jsx: true }),
-	plugins: ['import', 'react'],
-	rules: base.rules,
+	plugins: ['import', 'react', 'react-hooks'],
+	rules: Object.assign({}, base.rules, {
+		'react-hooks/rules-of-hooks': 'error',
+		'react-hooks/exhaustive-deps': 'error',
+	}),
 	settings: {
 		react: {
-			version: '16.3',
+			version: '16.8',
 		},
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-danbriggs5-react",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -474,6 +474,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
+      "integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
+      "dev": true
     },
     "eslint-restricted-globals": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-danbriggs5-react",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,8 @@
   "peerDependencies": {
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.16.0",
-    "eslint-plugin-react": "7.13.0"
+    "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react-hooks": "1.6.1"
   },
   "devDependencies": {
     "eslint": "5.16.0",
@@ -32,6 +33,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react-hooks": "1.6.1",
     "husky": "0.14.3",
     "prettier": "1.16.4"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-danbriggs5-react",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks).
- Switch to react version 16.8.
- Bump to 3.0.0 since it requires a new peer dep.